### PR TITLE
[doc] Fix badges in README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,8 @@ before_install:
 
 script:
   - flake8 .
-  - cd tests && ./run_tests.py
+  - cd tests
+  - coverage run --source=manuscript run_tests.py
+
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GrimoireLab Manuscripts [![Build Status](https://travis-ci.org/grimoirelab/reports.svg?branch=master)](https://travis-ci.org/grimoirelab/reports)
+# GrimoireLab Manuscripts [![Build Status](https://travis-ci.org/chaoss/grimoirelab-manuscripts.svg?branch=master)](https://travis-ci.org/chaoss/grimoirelab-manuscripts) [![Coverage Status](https://coveralls.io/repos/github/chaoss/grimoirelab-manuscripts/badge.svg?branch=master)](https://coveralls.io/github/chaoss/grimoirelab-manuscripts?branch=master)
 
 The aim of this project is the automatic generation of reports from the enriched indexes with items from perceval data sources (git commits, github pull requests, bugzilla bugs ...) enriched using GrimoireELK.
 


### PR DESCRIPTION
This code includes travis and coveralls badges for to ease the understanding of the status and test coverage of the repo.