### PR TITLE
[travis] Narrow coveralls execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 script:
   - flake8 .
   - cd tests
-  - coverage run run_tests.py
+  - coverage run --include=*manuscripts/manuscripts* run_tests.py
 
 after_success:
   - coveralls


### PR DESCRIPTION
This code restricts the execution of Coveralls only to the source code folders.