### PR TITLE
Convert 'extended_bounds' timestamps to integers

### DIFF
--- a/manuscripts/esquery.py
+++ b/manuscripts/esquery.py
@@ -245,10 +245,12 @@ class ElasticQuery():
                 start = start.replace(microsecond=0)
                 start_ts = start.replace(tzinfo=timezone.utc).timestamp()
                 start_ts_ms = start_ts * 1000  # ES uses ms
+                start_ts_ms = int(start_ts_ms)
             if end:
                 end = end.replace(microsecond=0)
                 end_ts = end.replace(tzinfo=timezone.utc).timestamp()
                 end_ts_ms = end_ts * 1000  # ES uses ms
+                end_ts_ms = int(end_ts_ms)
 
             bounds_data = {}
             if start:

--- a/tests/test_esquery.py
+++ b/tests/test_esquery.py
@@ -227,8 +227,8 @@ class TestEsquery(unittest.TestCase):
 
         test_bounds_dict = {
             "extended_bounds": {
-                "min": 1495497600000.0,
-                "max": 1527033600000.0
+                "min": 1495497600000,
+                "max": 1527033600000
             }
         }
         self.assertDictEqual(self.es._ElasticQuery__get_bounds(self.start, self.end), test_bounds_dict)
@@ -261,8 +261,8 @@ class TestEsquery(unittest.TestCase):
                 "time_zone": "UTC",
                 "min_doc_count": 0,
                 "extended_bounds": {
-                    "min": 1495497600000.0,
-                    "max": 1527033600000.0
+                    "min": 1495497600000,
+                    "max": 1527033600000
                 }
             },
             "aggs": {
@@ -404,8 +404,8 @@ class TestEsquery(unittest.TestCase):
                         "time_zone": "UTC",
                         "min_doc_count": 0,
                         "extended_bounds": {
-                            "min": 1495497600000.0,
-                            "max": 1527033600000.0
+                            "min": 1495497600000,
+                            "max": 1527033600000
                         }
                     },
                     "aggs": {


### PR DESCRIPTION
Elastic Search is unable to parse timestamps which have decimals. For example, when date `1530403199999.99` is used in a query, the system will give the next error: `1.53040319999999E12 cannot be converted to Long without data loss`.

This commit converts these timestamps to int types to avoid this problem.