### PR TITLE
[manuscripts2/elasticsearch] Add get_list method for Query class

### DIFF
--- a/manuscripts2/elasticsearch.py
+++ b/manuscripts2/elasticsearch.py
@@ -494,7 +494,6 @@ class Query():
         """
         Get time series data for the specified fields and period of analysis
 
-        :param query: a Query object with the necessary aggregations and filters
         :param child_agg_count: the child aggregation count to be used
                                 default = 0
         :param dataframe: if dataframe=True, return a pandas.DataFrame object
@@ -537,7 +536,6 @@ class Query():
         """
         Compute the values for single valued aggregations
 
-        :param query: a Query object with the necessary aggregations and filters
         :returns: the single aggregation value
         """
 
@@ -558,6 +556,25 @@ class Query():
             agg = res['hits']['total']
 
         return agg
+
+    def get_list(self, dataframe=False):
+        """
+        Compute the value for multi-valued aggregations
+
+        :returns: a dict containing 'keys' and their corresponding 'values'
+        """
+
+        res = self.fetch_aggregation_results()
+        keys = []
+        values = []
+        for bucket in res['aggregations'][str(self.parent_agg_counter - 1)]['buckets']:
+            keys.append(bucket['key'])
+            values.append(bucket['doc_count'])
+
+        result = {"keys": keys, "values": values}
+        if dataframe:
+            result = pd.DataFrame.from_records(result)
+        return result
 
 
 class PullRequests(Query):

--- a/tests/data/test_data/authors_list.json
+++ b/tests/data/test_data/authors_list.json
@@ -1,0 +1,4 @@
+{
+    "keys": ["Santiago Dueñas", "valerio cosentino", "Alvaro del Castillo", "Alberto Martín", "Jesus M. Gonzalez-Barahona", "quan", "Miguel Ángel Fernández", "David Pose Fernández", "camillem", "valerio", "David Esler", "Israel Herraiz", "J. Manrique Lopez de la Fuente", "Luis Cañas Díaz", "Prabhat", "Stephan Barth", "anveshc05", "david"],
+    "values": [759, 310, 56, 51, 19, 5, 3, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1]
+}

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -67,6 +67,7 @@ FETCH_SOURCE_RESULTS_DATA1 = "data/test_data/authors.json"
 TERMS_AGGREGATION_DATA = "data/test_data/terms_aggregation_authors.json"
 SUM_LINES_ADDED_BY_AUTHORS = "data/test_data/sum_lines_added_by_authors.json"
 NUM_HASHES_BY_QUARTER = "data/test_data/num_hashes_by_quarter.json"
+AUTHORS_LIST = "data/test_data/authors_list.json"
 
 
 def load_json_file(filename, mode="r"):
@@ -477,3 +478,14 @@ class TestElasticsearch(TestBaseElasticSearch):
         self.Query_test_object.get_cardinality(self.field2)
         num_authors = self.Query_test_object.get_aggs()
         self.assertEqual(NUM_AUTHORS, num_authors)
+
+    def test_get_list(self):
+        """
+        Testing multi valued aggregations.
+        """
+
+        self.Query_test_object.until(end=self.end)
+        self.Query_test_object.get_terms("author_name")
+        authors = self.Query_test_object.get_list()
+        authors_test = load_json_file(AUTHORS_LIST)
+        self.assertDictEqual(authors, authors_test)


### PR DESCRIPTION
This PR adds a `get_list` method, to the Query class, which returns
multi-valued aggregations as a dict/dataframe containing 'keys' as the
item names and 'values' as values corresponding to those item names.

This `get_list` function is inspired/copied by the [get_list function in metrics.py](https://github.com/chaoss/grimoirelab-manuscripts/blob/master/manuscripts/metrics/metrics.py#L132).

This PR also adds tests and test_data for `get_list` function.