### PR TITLE
[manuscripts2] Add functions to calculate the Project_Community metrics

### DIFF
--- a/manuscripts2/metrics/github_issues.py
+++ b/manuscripts2/metrics/github_issues.py
@@ -226,3 +226,25 @@ def project_activity(index, start, end):
     }
 
     return results
+
+
+def project_community(index, start, end):
+    """Compute the metrics for the project community section of the enriched
+    github issues index.
+
+    Returns a dictionary containing "author_metrics", "people_top_metrics"
+    and "orgs_top_metrics" as the keys and the related Metrics as the values.
+
+    :param index: index object
+    :param start: start date to get the data from
+    :param end: end date to get the data upto
+    :return: dictionary with the value of the metrics
+    """
+
+    results = {
+        "author_metrics": [],
+        "people_top_metrics": [],
+        "orgs_top_metrics": [],
+    }
+
+    return results

--- a/manuscripts2/metrics/github_prs.py
+++ b/manuscripts2/metrics/github_prs.py
@@ -217,3 +217,25 @@ def project_activity(index, start, end):
     }
 
     return results
+
+
+def project_community(index, start, end):
+    """Compute the metrics for the project community section of the enriched
+    github pull requests index.
+
+    Returns a dictionary containing "author_metrics", "people_top_metrics"
+    and "orgs_top_metrics" as the keys and the related Metrics as the values.
+
+    :param index: index object
+    :param start: start date to get the data from
+    :param end: end date to get the data upto
+    :return: dictionary with the value of the metrics
+    """
+
+    results = {
+        "author_metrics": [],
+        "people_top_metrics": [],
+        "orgs_top_metrics": [],
+    }
+
+    return results

--- a/tests/data/test_data/git_top_authors.json
+++ b/tests/data/test_data/git_top_authors.json
@@ -1,0 +1,5 @@
+{
+    "keys": ["valerio cosentino", "Santiago Dueñas", "Alvaro del Castillo", "Jesus M. Gonzalez-Barahona"],
+    "values": [13, 4, 2, 1]
+
+}

--- a/tests/data/test_data/git_top_organizations.json
+++ b/tests/data/test_data/git_top_organizations.json
@@ -1,0 +1,4 @@
+{
+    "keys": ["Unknown"],
+    "values": [20]
+}

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -20,14 +20,7 @@
 # Authors:
 #     Pranjal Aswani <aswani.pranjal@gmail.com>
 
-# TODO:
-# These tests will fail if some old PR is accepted and that code
-# is added to the master branch. To remedy that, we should look
-# into using github issues or prs instead of using git data source
-
-import os
 import sys
-import json
 
 from datetime import datetime
 
@@ -39,6 +32,7 @@ sys.path.insert(0, '..')
 
 from base import TestBaseElasticSearch
 from manuscripts2.elasticsearch import Query, Index
+from utils import load_json_file
 
 # We are going to insert perceval's data into elasticsearch
 # So that we can test the the functions
@@ -68,12 +62,6 @@ TERMS_AGGREGATION_DATA = "data/test_data/terms_aggregation_authors.json"
 SUM_LINES_ADDED_BY_AUTHORS = "data/test_data/sum_lines_added_by_authors.json"
 NUM_HASHES_BY_QUARTER = "data/test_data/num_hashes_by_quarter.json"
 AUTHORS_LIST = "data/test_data/authors_list.json"
-
-
-def load_json_file(filename, mode="r"):
-    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), filename), mode) as f:
-        json_content = json.load(f)
-    return json_content
 
 
 class TestElasticsearch(TestBaseElasticSearch):

--- a/tests/test_elasticsearch2.py
+++ b/tests/test_elasticsearch2.py
@@ -20,20 +20,10 @@
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
 
-
-import os
-import json
-
 from base import TestBaseElasticSearch
 
 NAME = "git_commit"
 ENRICH_INDEX = "git_enrich"
-
-
-def load_json_file(filename, mode="r"):
-    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), filename), mode) as f:
-        json_content = json.load(f)
-    return json_content
 
 
 class TestGit(TestBaseElasticSearch):

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -32,6 +32,8 @@ from numpy.testing import assert_array_equal
 
 from manuscripts2.metrics import git
 from manuscripts2.elasticsearch import Query, Index, get_trend
+
+from utils import load_json_file
 from base import TestBaseElasticSearch
 
 
@@ -45,6 +47,8 @@ TREND_PRECENTAGE = -41
 # files
 AUTHORS_BY_PERIOD = "data/test_data/git_authors_by_months.csv"
 COMMITS_BY_PERIOD = "data/test_data/git_commits_by_months.csv"
+TOP_AUTHORS = "data/test_data/git_top_authors.json"
+TOP_ORGANIZATIONS = "data/test_data/git_top_organizations.json"
 
 
 class TestGit(TestBaseElasticSearch):
@@ -138,3 +142,25 @@ class TestGit(TestBaseElasticSearch):
         authors_test = pd.read_csv(AUTHORS_BY_PERIOD)
         self.assertIsInstance(authors_ts, pd.DataFrame)
         assert_array_equal(authors_test['value'], authors_ts['value'])
+
+    def test_authors_list(self):
+        """
+        Test if the list of top authors is returned correctly or not.
+        """
+
+        authors = git.Authors(self.git_index, self.start, self.end)
+        authors_list = authors.aggregations()
+        authors_test = load_json_file(TOP_AUTHORS)
+        assert_array_equal(authors_list['keys'], authors_test['keys'])
+        assert_array_equal(authors_list['values'], authors_test['values'])
+
+    def test_organization_list(self):
+        """
+        Test if the list of top organizations is returned correctly or not.
+        """
+
+        orgs = git.Organizations(self.git_index, self.start, self.end)
+        orgs_list = orgs.aggregations()
+        orgs_test = load_json_file(TOP_ORGANIZATIONS)
+        assert_array_equal(orgs_list['keys'], orgs_test['keys'])
+        assert_array_equal(orgs_list['values'], orgs_test['values'])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,36 +22,19 @@
 # Author:
 #   Pranjal Aswani <aswani.pranjal@gmail.com>
 
-
-from dateutil import relativedelta
-
-
-def get_prev_month(end_date, interval):
-
-    if interval not in ['month', 'quarter', 'year']:
-        raise RuntimeError("Interval not supported ", interval)
-    if interval == 'month':
-        end_prev_month = end_date - relativedelta.relativedelta(months=1)
-    elif interval == 'quarter':
-        end_prev_month = end_date - relativedelta.relativedelta(months=3)
-    elif interval == 'year':
-        end_prev_month = end_date - relativedelta.relativedelta(months=12)
-
-    return end_prev_month
+import os
+import json
 
 
-def str_val(val):
+def load_json_file(filename, mode="r"):
     """
-    Format the value of a metric value to a string
+    Load a json file and return the data.
 
-    :param val: number to be formatted
-    :return: a string with the formatted value
+    :param filename: the name of the json file to be loaded
+    :param mode: the mode to open the file in. Default: 'r'
+    :returns: content of the json file as a python dict
     """
-    str_val = val
-    if val is None:
-        str_val = "NA"
-    elif type(val) == float:
-        str_val = '%0.2f' % val
-    else:
-        str_val = str(val)
-    return str_val
+
+    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), filename), mode) as f:
+        json_content = json.load(f)
+    return json_content


### PR DESCRIPTION
This PR adds the function `project_community` for the `git`, `github_prs` and `github_issues` data sources. `github_prs` and `github_issues` do not have any Metrics under this section hence the values are empty lists for these data sources.

For `git` data source, the aggregations() method in `Authors` class is modified to return a list of top performing authors in the previous time interval.
Similarly an `Organizations` class is added with an `aggregations` method to return the list of top organizations in the previous time interval.

This PR also adds the tests and test data for the aggregations methods of the Authors and Organizations classes.

