### PR TITLE
[MS2/latex] Separate github_issues and github_prs data for Overview

### DIFF
--- a/manuscripts2/latex_template/overview/efficiency-github_issues.tex
+++ b/manuscripts2/latex_template/overview/efficiency-github_issues.tex
@@ -1,18 +1,16 @@
 In order to provide some insight into the software development process of PROJECT-NAME community, several metrics on GitHub issues and pull requests are presented below. In terms of GitHub terminology, these metrics are calculated as follows:
 \begin{itemize}
-	\item Review Efficiency Index (REI), measured as the number of closed pull requests out of the new ones in a given period.
-	\item Time to Merge (TTM), measured as the time since a pull request is submitted until this is closed.
-	\item Backlog Management Index (BMI), measured as the number of closed tickets out of open tickets in a given period.
-	\item Time to Close issues (TTC), the time since an issue was opened till this is closed.
+    \item Backlog Management Index (BMI), measured as the number of closed tickets out of open tickets in a given period.
+    \item Time to Close issues (TTC), the time since an issue was opened till this is closed.
 \end{itemize}
 
 
 \begin{table}[H]
     \centering
     \begin{tabular}{c|c|c|l}%
-    \bfseries  REI  & \bfseries BMI & \bfseries TTM  & \bfseries TTC
+    \bfseries BMI & \bfseries TTC
     \csvreader[head to column names]{overview/efficiency.csv}{}% use head of csv as column names
-    {\\\bmipr & \bmitickets & \daystocloseprmedian ~ days & \daystocloseticketmedian ~ days}
+    {\\\bmitickets & \daystocloseticketmedian ~ days}
     \end{tabular}
-    \caption{Closed out of opened pull requests(REI), closed out of opened issues (BMI), median time to merge pull requests (TTM) and median time to close issues(TTC)}
+    \caption{Closed out of opened issues (BMI), median time to close issues(TTC)}
 \end{table}

--- a/manuscripts2/latex_template/overview/efficiency-github_prs.tex
+++ b/manuscripts2/latex_template/overview/efficiency-github_prs.tex
@@ -1,0 +1,14 @@
+\begin{itemize}
+	\item Review Efficiency Index (REI), measured as the number of closed pull requests out of the new ones in a given period.
+	\item Time to Merge (TTM), measured as the time since a pull request is submitted until this is closed.
+\end{itemize}
+
+\begin{table}[H]
+    \centering
+    \begin{tabular}{c|c|c|l}%
+    \bfseries  REI  & \bfseries TTM
+    \csvreader[head to column names]{overview/efficiency.csv}{}% use head of csv as column names
+    {\\\bmipr & \daystocloseprmedian ~ days}
+    \end{tabular}
+    \caption{Closed out of opened pull requests(REI), median time to merge pull requests (TTM)}
+\end{table}

--- a/manuscripts2/report.py
+++ b/manuscripts2/report.py
@@ -603,7 +603,7 @@ class Report():
 
         # Overview section
         overview = r'\input{overview/summary.tex}'
-        for overview_ds in ['github_issues']:
+        for overview_ds in ['github_issues', 'github_prs']:
             if overview_ds in self.data_sources:
                 overview += r"\input{overview/efficiency-" + overview_ds + ".tex}\n"
         with open(os.path.join(report_path, "overview.tex"), "w") as flatex:


### PR DESCRIPTION
This code splits the efficiency-github_issues.tex file into two:
efficiency-github_issues.tex and efficiency-github_prs.tex.

Earlier, if github_prs data source was not added to the report, then a latex error
was thrown because the latex template, for the over view section of the report,
expected a column name from a file which generated from the github_prs data source
but since the data source was not added, the file wasn't created and hence
there was no column name matching that latex template.

This code tries to fix that bug by splitting the template file into two parts,
one for each data source.