### PR TITLE
[MS2/tests] Set up module level test fixtures

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -21,42 +21,17 @@
 #     Valerio Cosentino <valcos@bitergia.com>
 #
 
-import json
-import os
 import unittest
-from elasticsearch import Elasticsearch, helpers
+from elasticsearch import Elasticsearch
 
 
 ES_URL = "http://127.0.0.1:9200"
 
 
 class TestBaseElasticSearch(unittest.TestCase):
+    """
+    Test base class from which all the test classes inherit.
+    All the variables common to the tests can be declared here.
+    """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.es = Elasticsearch([ES_URL], timeout=3600, max_retries=50, retry_on_timeout=True)
-
-        with open(os.path.join("data/mappings", cls.name + "_mappings.json")) as f:
-            mappings = json.load(f)
-
-        with open(os.path.join("data/indices", cls.name + ".json")) as f:
-            docs = []
-            for line in f.readlines():
-                doc = json.loads(line)
-                docs.append(doc)
-
-        if cls.es.indices.exists(index=cls.enrich_index):
-            cls.es.indices.delete(index=cls.enrich_index)
-
-        cls.es.indices.create(index=cls.enrich_index, body=mappings)
-
-        for doc in docs:
-            doc['_index'] = cls.enrich_index
-            cls.es.indices.refresh(index=cls.enrich_index)
-            helpers.bulk(cls.es, [doc], raise_on_error=True)
-
-        cls.es.indices.refresh(index=cls.enrich_index)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.es.indices.delete(index=cls.enrich_index)
+    es = Elasticsearch([ES_URL], timeout=3600, max_retries=50, retry_on_timeout=True)

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -36,10 +36,7 @@ from utils import load_json_file
 
 # We are going to insert perceval's data into elasticsearch
 # So that we can test the the functions
-ES_URL = "http://127.0.0.1:9200"
-NAME = "git_commit"
 ENRICH_INDEX = "git_enrich"
-
 
 # Some aggregation results as seen on 10th July 2018
 NUM_COMMITS = 1217
@@ -68,12 +65,6 @@ class TestElasticsearch(TestBaseElasticSearch):
     """Base class to test new_functions.py"""
 
     maxDiff = None
-
-    @classmethod
-    def setUpClass(cls):
-        cls.name = NAME
-        cls.enrich_index = ENRICH_INDEX
-        super().setUpClass()
 
     def setUp(self):
         """Set up the necessary functions to run unittests"""

--- a/tests/test_elasticsearch2.py
+++ b/tests/test_elasticsearch2.py
@@ -22,24 +22,17 @@
 
 from base import TestBaseElasticSearch
 
-NAME = "git_commit"
 ENRICH_INDEX = "git_enrich"
 
 
 class TestGit(TestBaseElasticSearch):
     """Base class to test new_functions.py"""
 
-    @classmethod
-    def setUpClass(cls):
-        cls.name = NAME
-        cls.enrich_index = ENRICH_INDEX
-        super().setUpClass()
-
     def test_read_items(self):
         """Check that the items fetched from the data folder are correctly loaded"""
 
         page = self.es.search(
-            index=self.enrich_index,
+            index=ENRICH_INDEX,
             scroll="60m",
             size=200,
             body={"query": {"match_all": {}}}

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -37,7 +37,6 @@ from utils import load_json_file
 from base import TestBaseElasticSearch
 
 
-NAME = "git_commit"
 ENRICH_INDEX = "git_enrich"
 
 # All values as seen on 2018-07-10
@@ -55,16 +54,6 @@ class TestGit(TestBaseElasticSearch):
     """
     Test the git data source.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Setup necessary infrastructure to test the functions.
-        """
-
-        cls.name = NAME
-        cls.enrich_index = ENRICH_INDEX
-        super().setUpClass()
 
     def setUp(self):
         """

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -35,7 +35,6 @@ from manuscripts2.elasticsearch import Query, Index, get_trend
 from base import TestBaseElasticSearch
 
 
-NAME = "github_issues"
 ENRICH_INDEX = "github_issues_enrich"
 
 # All values as seen on 2018-07-10
@@ -60,16 +59,6 @@ class TestGitHubIssues(TestBaseElasticSearch):
     """
     Test the github_issues data source.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Setup necessary infrastructure to test the functions.
-        """
-
-        cls.name = NAME
-        cls.enrich_index = ENRICH_INDEX
-        super().setUpClass()
 
     def setUp(self):
         """

--- a/tests/test_github_prs.py
+++ b/tests/test_github_prs.py
@@ -35,7 +35,6 @@ from manuscripts2.elasticsearch import Query, Index, get_trend
 from base import TestBaseElasticSearch
 
 
-NAME = "github_prs"
 ENRICH_INDEX = "github_prs_enrich"
 
 # All values as seen on 2018-07-10
@@ -60,16 +59,6 @@ class TestGitHubPRs(TestBaseElasticSearch):
     """
     Test the github_pull_requests data source.
     """
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Setup necessary infrastructure to test the functions.
-        """
-
-        cls.name = NAME
-        cls.enrich_index = ENRICH_INDEX
-        super().setUpClass()
 
     def setUp(self):
         """


### PR DESCRIPTION
Currently, at the beginning of running each test class,
an ES index is created for that class from json files stored in
data/indices dir.

These indices are setup so that data from these indices can be used
to test the functions related to that data source (git, github_issues)

Now, since these indices will be used to generate the report too,
this code proposes to add Module level fixtures to the tests which
will index the data related to testing into ES only once, when the tests
aer starting to run. And these module level fixtures will also remove the
indices once the tests are complete.

In this way, we won't have to index the data again and again and this
will save us time.

This is a rest run on my machine:

The first round of tests is with the module level fixtures, the second round is the current normal test run. It shaves approximately 1:30 minutes from testing.
![screen shot 2018-08-10 at 1 36 03 pm](https://user-images.githubusercontent.com/9946566/43946609-5480c0b8-9ca3-11e8-956e-2e6a252af498.png)
