### PR TITLE
Use closing date on GitHub PRs when computing BMI metric

### DIFF
--- a/manuscripts/metrics/gerrit.py
+++ b/manuscripts/metrics/gerrit.py
@@ -170,13 +170,13 @@ class BMI(GerritMetrics):
                         start=self.start, end=self.end,
                         esfilters=esfilters_merge, interval=self.interval)
         # For BMI we need when the ticket was closed
-        merged.DATE_FIELD = 'closed'
+        merged.FIELD_DATE = 'closed'
 
         abandoned = Abandoned(self.es_url, self.es_index,
                               start=self.start, end=self.end,
                               esfilters=esfilters_abandon, interval=self.interval)
         # For BMI we need when the ticket was closed
-        abandoned.DATE_FIELD = 'closed'
+        abandoned.FIELD_DATE = 'closed'
 
         submitted = Submitted(self.es_url, self.es_index,
                               start=self.start, end=self.end,

--- a/manuscripts/metrics/github_prs.py
+++ b/manuscripts/metrics/github_prs.py
@@ -147,7 +147,7 @@ class BMIPR(GitHubPRsMetrics):
                           start=self.start, end=self.end,
                           esfilters=esfilters_close, interval=self.interval)
         # For BMI we need when the ticket was closed
-        closed.DATE_FIELD = 'updated_at'
+        closed.FIELD_DATE = 'closed_at'
         submitted = SubmittedPR(self.es_url, self.es_index,
                                 start=self.start, end=self.end,
                                 esfilters=esfilters_submit,


### PR DESCRIPTION
BMI metrics for ITS data sources (i.e Jira or GitHub issues) use 'closed_at' on closed issues. For GitHub PRs, 'updated_at' was being used. This value is invalid because there can be activity not related with the work on that PR (i.e updates by GitHub maintainers).