### PR TITLE
[manuscripts] Update license and copyright info

### DIFF
--- a/bin/manuscripts
+++ b/bin/manuscripts
@@ -1,9 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-#  Script for producing Reports from data in ElasticSearch
-#
-# Copyright (C) 2017 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +13,10 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-# git.Authors:
-#   Alvaro del Castillo San Felix <acs@bitergia.com>
+# Authors:
+#     Alvaro del Castillo San Felix <acs@bitergia.com>
 #
 
 import argparse

--- a/bin/manuscripts2
+++ b/bin/manuscripts2
@@ -1,9 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-#  Script for producing Reports from data in ElasticSearch
-#
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#       Pranjal Aswani <aswani.pranjal@gmail.com>
+#     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 
 import os

--- a/manuscripts/config.py
+++ b/manuscripts/config.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2017 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,13 +13,13 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#       Alvaro del Castillo <acs@bitergia.com>
-#       Luis Cañas-Díaz <lcanas@bitergia.com>
-#       Quan Zhou <quan@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
+#     Luis Cañas-Díaz <lcanas@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
+#
 
 
 import configparser

--- a/manuscripts/esquery.py
+++ b/manuscripts/esquery.py
@@ -1,9 +1,6 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
-# Helper classes for doing queries to ElasticSearch
-#
-# Copyright (C) 2016 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +13,10 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#     Alvaro del Castillo San Felix <acs@bitergia.com>
 #
 
 from datetime import timezone

--- a/manuscripts/metrics/__init__.py
+++ b/manuscripts/metrics/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2012-2014 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,10 +13,9 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#         Daniel Izquierdo <dizquierdo@bitergia.com>
-#         Alvaro del Castillo <acs@bitergia.com>
+#     Daniel Izquierdo <dizquierdo@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
 #

--- a/manuscripts/metrics/gerrit.py
+++ b/manuscripts/metrics/gerrit.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2016 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,13 +13,12 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-#
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Alvaro del Castillo <acs@bitergia.com>
-#   Daniel Izquierdo <dizquierdo@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
+#     Daniel Izquierdo <dizquierdo@bitergia.com>
+#
 
 from .metrics import Metrics
 

--- a/manuscripts/metrics/git.py
+++ b/manuscripts/metrics/git.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python3
-# Copyright (C) 2014 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,16 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-#
-# This file is a part of GrimoireLib
-#  (an Python library for the MetricsGrimoire and vizGrimoire systems)
-#
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Daniel Izquierdo-Cortazar <dizquierdo@bitergia.com>
-#   Alvaro del Castillo  <acs@bitergia.com>
+#     Daniel Izquierdo-Cortazar <dizquierdo@bitergia.com>
+#     Alvaro del Castillo  <acs@bitergia.com>
 #
 
 from .metrics import Metrics

--- a/manuscripts/metrics/github_issues.py
+++ b/manuscripts/metrics/github_issues.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,16 +13,12 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-#
-# This file is a part of GrimoireLib
-#  (an Python library for the MetricsGrimoire and vizGrimoire systems)
-#
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Alvaro del Castillo <acs@bitergia.com>
-#   Daniel Izquierdo <dizquierdo@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
+#     Daniel Izquierdo <dizquierdo@bitergia.com>
+#
 
 from . import its
 

--- a/manuscripts/metrics/github_prs.py
+++ b/manuscripts/metrics/github_prs.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,16 +13,12 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-#
-# This file is a part of GrimoireLib
-#  (an Python library for the MetricsGrimoire and vizGrimoire systems)
-#
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Alvaro del Castillo <acs@bitergia.com>
-#   Daniel Izquierdo <dizquierdo@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
+#     Daniel Izquierdo <dizquierdo@bitergia.com>
+#
 
 from .metrics import Metrics
 

--- a/manuscripts/metrics/its.py
+++ b/manuscripts/metrics/its.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,15 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-#
-# This file is a part of GrimoireLib
-#  (an Python library for the MetricsGrimoire and vizGrimoire systems)
-#
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Alvaro del Castillo <acs@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
+#
 
 """ Metrics for the issue tracking system """
 

--- a/manuscripts/metrics/jira.py
+++ b/manuscripts/metrics/jira.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,16 +13,12 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-#
-# This file is a part of GrimoireLib
-#  (an Python library for the MetricsGrimoire and vizGrimoire systems)
-#
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Alvaro del Castillo <acs@bitergia.com>
-#   Daniel Izquierdo <dizquierdo@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
+#     Daniel Izquierdo <dizquierdo@bitergia.com>
+#
 
 from . import its
 from .metrics import Metrics

--- a/manuscripts/metrics/metrics.py
+++ b/manuscripts/metrics/metrics.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python3
-# Copyright (C) 2016 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,16 +13,12 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-#
-# This file is a part of GrimoireLib
-#  (an Python library for the MetricsGrimoire and vizGrimoire systems)
-#
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Daniel Izquierdo-Cortazar <dizquierdo@bitergia.com>
-#   Alvaro del Castillo <acs@bitergia.com>
+#     Daniel Izquierdo-Cortazar <dizquierdo@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
+#
 
 import logging
 

--- a/manuscripts/metrics/mls.py
+++ b/manuscripts/metrics/mls.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,16 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-#
-# This file is a part of GrimoireLib
-#  (an Python library for the MetricsGrimoire and vizGrimoire systems)
-#
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Daniel Izquierdo-Cortazar <dizquierdo@bitergia.com>
-#   Alvaro del Castillo <acs@bitergia.com>
+#     Daniel Izquierdo-Cortazar <dizquierdo@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
 #
 
 from .metrics import Metrics

--- a/manuscripts/metrics/stackexchange.py
+++ b/manuscripts/metrics/stackexchange.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2017 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,12 +13,10 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-#
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Alvaro del Castillo <acs@bitergia.com>
+#     Alvaro del Castillo <acs@bitergia.com>
 #
 
 from .metrics import Metrics

--- a/manuscripts/report.py
+++ b/manuscripts/report.py
@@ -1,9 +1,6 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
-#  Script for producing Reports from data in ElasticSearch
-#
-# Copyright (C) 2016 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +13,10 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Author:
-#   Alvaro del Castillo San Felix <acs@bitergia.com>
+#     Alvaro del Castillo San Felix <acs@bitergia.com>
 #
 
 import logging

--- a/manuscripts2/elasticsearch.py
+++ b/manuscripts2/elasticsearch.py
@@ -1,9 +1,6 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
-# Classes for querying ElasticSearch and calculating the metrics
-#
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
-#   Pranjal Aswani <aswani.pranjal@gmail.com>
+#     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 from dateutil import parser
 from datetime import timezone

--- a/manuscripts2/metrics/git.py
+++ b/manuscripts2/metrics/git.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
-#
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Author:
-#   Pranjal Aswani <aswani.pranjal@gmail.com>
+#     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 from manuscripts2.elasticsearch import Query
 from manuscripts2.utils import get_prev_month

--- a/manuscripts2/metrics/github_issues.py
+++ b/manuscripts2/metrics/github_issues.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
-#
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Author:
-#   Pranjal Aswani <aswani.pranjal@gmail.com>
+#     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 from manuscripts2.elasticsearch import Issues, calculate_bmi
 from manuscripts2.utils import get_prev_month

--- a/manuscripts2/metrics/github_prs.py
+++ b/manuscripts2/metrics/github_prs.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
-#
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Author:
-#   Pranjal Aswani <aswani.pranjal@gmail.com>
+#     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 from manuscripts2.elasticsearch import PullRequests, calculate_bmi
 from manuscripts2.utils import get_prev_month

--- a/manuscripts2/report.py
+++ b/manuscripts2/report.py
@@ -1,7 +1,6 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Author:
-#   Pranjal Aswani <aswani.pranjal@gmail.com>
+#     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 import os
 import sys

--- a/manuscripts2/utils.py
+++ b/manuscripts2/utils.py
@@ -1,9 +1,6 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
-#  Script for producing Reports from data in ElasticSearch
-#
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Author:
-#   Pranjal Aswani <aswani.pranjal@gmail.com>
+#     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 
 from dateutil import relativedelta

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2017 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2016 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2017 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 import sys
 

--- a/tests/test_elasticsearch2.py
+++ b/tests/test_elasticsearch2.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
+#
 
 from base import TestBaseElasticSearch
 

--- a/tests/test_esquery.py
+++ b/tests/test_esquery.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 import sys
 import unittest

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 
 import sys

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 
 import sys

--- a/tests/test_github_prs.py
+++ b/tests/test_github_prs.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 
 import sys

--- a/tests/test_manuscripts2_report.py
+++ b/tests/test_manuscripts2_report.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 import os
 import sys

--- a/tests/test_task_report.py
+++ b/tests/test_task_report.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2017 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Alvaro del Castillo <acs@bitergia.com>
+#
 
 
 import os

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,6 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
-#  Script for producing Reports from data in ElasticSearch
-#
-# Copyright (C) 2018 CHAOSS
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,11 +13,11 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Author:
-#   Pranjal Aswani <aswani.pranjal@gmail.com>
+#     Pranjal Aswani <aswani.pranjal@gmail.com>
+#
 
 import os
 import json


### PR DESCRIPTION
This code updates the license info based on the content of https://www.gnu.org/licenses/gpl-3.0.html. Furthermore, it also aligns and updates the copyright info.