### PR TITLE
Added first line to make these files executable.

### DIFF
--- a/bin/manuscripts
+++ b/bin/manuscripts
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia

--- a/bin/manuscripts2
+++ b/bin/manuscripts2
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2019 Bitergia


### PR DESCRIPTION
Somehow, the first line of these two files was removed in
the previous commit, which prevents them from being
directly executable, without prefixing with "python".
This fix reverts that line to the file.
