### PR TITLE
[travis] Support for python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 
 python:
-  - "3.4"
+  - "3.5"
+  - "3.6"
 
 sudo: false
 


### PR DESCRIPTION
   
This code aims at aligning the CI tests across the  different grimoirelab components.
   
Python 3.4 is removed and Python 3.5 and 3.6 are now supported.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>